### PR TITLE
座標の変換処理を修正

### DIFF
--- a/src/js/renderer/Map.js
+++ b/src/js/renderer/Map.js
@@ -166,9 +166,11 @@ Map.prototype.init = function () {
  */
 Map.prototype.render = function ( coordinate ) {
   var adjustedCor = {
-    x: parseFloat(coordinate.x),
-    // Y 軸の向きを 下 -> 上 にするために，-1 をかける
-    y: parseFloat(coordinate.y) * -1
+    // [機体内での座標] -> x軸: ↑, y軸: ←
+    // [画像を描画するときの座標]-> x軸: →, y軸: ↓
+    // [機体内での座標]を[描画するときの座標]に変換して代入する
+    x: parseFloat(coordinate.y) * -1,
+    y: parseFloat(coordinate.x) * -1
   };
 
   // [機体内での座標]での単位: cm

--- a/src/js/renderer/Map.js
+++ b/src/js/renderer/Map.js
@@ -171,10 +171,12 @@ Map.prototype.render = function ( coordinate ) {
     y: parseFloat(coordinate.y) * -1
   };
 
-  // スケールに合わせる
+  // [機体内での座標]での単位: cm
+  // [画像を描画するときの座標]での単位: px
+  // スケールに合わせる([cm] -> [px])
   if ( ! isNaN(this.drawScale) ) {
-    adjustedCor.x /= this.drawScale;
-    adjustedCor.y /= this.drawScale;
+    adjustedCor.x *= this.drawScale;
+    adjustedCor.y *= this.drawScale;
   }
 
   // 原点に合わせる


### PR DESCRIPTION
以下の問題を修正しました
- 機体の内部での位置とマップに描画したときの位置(距離)がずれる
- 機体での座標の向きが違っていた(前に進んだ時に横にいくように描画されていた)

正しく設定した時、線に沿うように軌跡が表示されるようになりました