### PR TITLE
electronのバージョンを最新版に

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,25 @@ EV3 と Bluetooth 接続すると，機体の状態をリアルタイムで確�
 
 ABI のバージョンが node / electron 間で異なるとエラーが生じる( issue #6 )。
 
-- node: `v6.x`
+
+- node: `v6.0`以上
+
+## 実行方法(開発時)
+
+nodeモジュールのインストール
+```
+npm install
+```
+
+node / electron 間のABIバージョンを合わせるためリビルドする
+```
+./node_modules/.bin/electron-rebuild
+```
+
+実行
+```
+./run.sh
+```
 
 ## TODO
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "bluetooth-serial-port": "2.1.0",
     "bootstrap": "^3.3.7",
     "date-utils": "1.2.7",
-    "electron-prebuilt": "1.1.3",
     "jsonschema": "^1.1.1"
+  },
+  "devDependencies": {
+    "electron": "^1.7.4",
+    "electron-rebuild": "^1.5.11"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "終了するには Ctrl-C を押すか Command-Q で終了してください"
-node_modules/electron-prebuilt/dist/Electron.app/Contents/MacOS/Electron .
+node_modules/.bin/electron .


### PR DESCRIPTION
`electron`のバージョンを最新版に変更しました。
また、`electron-rebuild`すると`node`と`electron`のバージョンの違いをあまり気にしなくて良くなることがわかったので、`README`に`electron-rebuild`する記述を追加しました。