### PR TITLE
縮尺100%以上にできるように

### DIFF
--- a/src/js/imageViewer.js
+++ b/src/js/imageViewer.js
@@ -48,7 +48,6 @@ function imageViewer () {
  * スケールアップボタン押下時に呼び出されるイベントハンドラ
  */
 imageViewer.prototype.onScaleup = function ( event ) {
-  if ( this.stateMap.image_scale >= 100 ) { return; }
   this.setScale( parseInt(this.stateMap.image_scale) + 10 );
 };
 


### PR DESCRIPTION
画像の縮尺を100%以上にしたい時、数値を入力すれば出来たのですが、ボタンクリックで拡大ができなかったので変更しました。