### PR TITLE
設定ファイルを共有しやすく

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ node / electron 間のABIバージョンを合わせるためリビルドする
 ./run.sh
 ```
 
+## ログファイルについて
+### 保存先
+
+デフォルトでは`[.appファイル]/Contents/Resources/app/log`にファイルが保存されます．
+
+### ファイル名
+起動画面の`Name:`欄の名前に，`_[デバイス名].json`をつけた名前で保存されます．
+
 ## TODO
 
 > [Home · selab601/ETRobocon-Logger Wiki](https://github.com/selab601/ETRobocon-Logger/wiki)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,25 @@ EV3 と Bluetooth 接続すると，機体の状態をリアルタイムで確�
 
 ABI のバージョンが node / electron 間で異なるとエラーが生じる( issue #6 )。
 
-- node: `v6.x`
+
+- node: `v6.0`以上
+
+## 実行方法(開発時)
+
+nodeモジュールのインストール
+```
+npm install
+```
+
+node / electron 間のABIバージョンを合わせるためリビルドする
+```
+./node_modules/.bin/electron-rebuild
+```
+
+実行
+```
+./run.sh
+```
 
 ## TODO
 

--- a/lib/deviceConnector.js
+++ b/lib/deviceConnector.js
@@ -50,16 +50,20 @@ deviceConnector.prototype.setEventHandlers = function () {
 
   this.ipc.on('connectDevice', (event, arg) => {
     console.log("Connecting...");
-    var address = arg;
+    var address = arg.address;
+    var name = arg.name;
+
     this.btSerial.findSerialPortChannel(address, function(channel) {
       this.btSerial.connect(address, channel, function() {
-        console.log('connected');
+        console.log('connected to ' + name);
 
         event.sender.send('connectDeviceComplete', {
           title: "Cnnected!",
-          body: "Successfully connected!!"
+          body: "Successfully connected to " + name + "!!"
         });
 
+        // デバイス名をセットする(ファイル名につけるため)
+        this.model.data.setting.device_name = name;
         // 設定をログファイルのヘッダに書き込む
         this.fileManager.appendSettings();
 
@@ -88,7 +92,7 @@ deviceConnector.prototype.setEventHandlers = function () {
   });
 
   this.ipc.on('disconnectDevice', (event, arg) => {
-    console.log("Disconnected");
+    console.log("Disconnected" + this.model.data.setting.device_name);
     this.btSerial.close();
     this.btSerial = new (require('bluetooth-serial-port')).BluetoothSerialPort();
 
@@ -99,7 +103,7 @@ deviceConnector.prototype.setEventHandlers = function () {
 
     event.sender.send('disconnectDeviceComplete', {
       title: "Disconnected",
-      body: "This connection's data was saved in " + arg + "."
+      body: "This connection's data was saved in " + this.fileManager.getLogfileName() + "."
     });
   });
 };

--- a/lib/fakeConnector.js
+++ b/lib/fakeConnector.js
@@ -57,17 +57,20 @@ fakeConnector.prototype.setEventHandlers = function () {
   this.ipc.on('connectDevice', (event, arg) => {
     console.log("Connecting...");
 
-    var address = arg;
+    var address = arg.address;
+    var name = arg.name;
 
-    console.log('connected');
+    console.log('connected to ' + name);
 
     event.sender.send('connectDeviceComplete', {
       title: "Cnnected!",
-      body: "Successfully connected!!"
+      body: "Successfully connected to " + name + "!!"
     });
 
     this.isConnected = true;
 
+    // デバイス名をセットする(ファイル名につけるため)
+    this.model.data.setting.device_name = name;
     // 設定をログファイルのヘッダに書き込む
     this.fileManager.appendSettings();
 
@@ -98,7 +101,7 @@ fakeConnector.prototype.setEventHandlers = function () {
   });
 
   this.ipc.on('disconnectDevice', (event, arg) => {
-    console.log("Disconnected");
+    console.log("Disconnected" + this.model.data.setting.device_name);
 
     this.isConnected = false;
 
@@ -110,7 +113,7 @@ fakeConnector.prototype.setEventHandlers = function () {
 
     event.sender.send('disconnectDeviceComplete', {
       title: "Disconnected",
-      body: "This connection's data was saved in " + arg + "."
+      body: "This connection's data was saved in " + this.fileManager.getLogfileName() + "."
     });
   });
 };

--- a/lib/fileManager.js
+++ b/lib/fileManager.js
@@ -30,10 +30,10 @@ fileManager.prototype.appendSettings = function () {
   var logFilePath = this.getLogfilePath();
   if ( logFilePath === undefined ) { return; }
 
-  var settings = this.model.getSettings();
-  if ( settings != undefined ) {
+  var header = this.model.getHeader();
+  if ( header != undefined ) {
     // ヘッダーを書き込む
-    this.file.appendFileSync( logFilePath, JSON.stringify(settings) + "\n", 'utf8' );
+    this.file.appendFileSync( logFilePath, JSON.stringify(header) + "\n", 'utf8' );
   }
   // ヘッダーの終わりだとわかる記号 (End Of Header)
   this.file.appendFileSync( logFilePath, "EOH\n", 'utf8' );

--- a/lib/fileManager.js
+++ b/lib/fileManager.js
@@ -15,8 +15,16 @@ function fileManager ( mainWindow, appPath, model ) {
 fileManager.prototype.getLogfilePath = function () {
   var data = this.model.getLogSettings();
   if ( data.logFileFolder == '' || data.logFileName == '' ) { return undefined; }
-  return data.logFileFolder + '/' + data.logFileName;
+  return data.logFileFolder + '/' + this.getLogfileName();
 };
+
+fileManager.prototype.getLogfileName = function () {
+  var data = this.model.getLogSettings();
+  if (data.logFileName == '') { return undefined; }
+  return data.logFileName + '_' + this.model.data.setting.device_name + '.json';
+
+}
+
 
 fileManager.prototype.appendSettings = function () {
   var logFilePath = this.getLogfilePath();
@@ -43,15 +51,23 @@ fileManager.prototype.updateLogFileName = function () {
   var formatted = date.toFormat("YYYY_MMDD_HH24MISS");
 
   // アプリケーションのパスで出力先ディレクトリを初期化する
-  var logFileFolder = data.logFileFolder == '' ? this.appPath + '/log' : data.logFileFolder;
+  if (data.logFileFolder == '') {
+      logFileFolder = this.appPath + '/log';
+      if (!this.file.existsSync(logFileFolder)) {
+          console.log(logFileFolder + "doesn't exist");
+          this.file.mkdirSync(logFileFolder);
+      }
+
+  }
+
   var default_path = this.model.data.setting.default_log_directory_path;
   if ( default_path != '' ) {
     logFileFolder = default_path;
   }
-  var logFileName   = formatted + '.json';
 
-  this.model.data.app.logFileName = logFileName;
+  this.model.data.app.logFileName = formatted;
   this.model.data.app.logFileFolder = logFileFolder;
+  console.log("fileManager.updateLogFileName, fileName: " + this.getLogfileName());
 };
 
 module.exports = fileManager;

--- a/lib/model.js
+++ b/lib/model.js
@@ -22,7 +22,8 @@ function model( win ) {
       image_original_size : {},
       start_point         : {},
       draw_scale          : 0,
-      draw_rotate         : 0
+      draw_rotate         : 0,
+      device_name         : '',
     }
   };
   this.win = win;

--- a/lib/model.js
+++ b/lib/model.js
@@ -99,6 +99,18 @@ model.prototype.getSettings = function () {
   return this.data.setting;
 };
 
+/**
+  * ログファイル用のヘッダを返す
+  */
+model.prototype.getHeader = function () {
+  // data.settingオブジェクトをコピーする(変更の影響を与えないように)
+  var header = Object.assign({}, this.data.setting);
+  // appディレクトリ以下が設定されている時、相対パス表現で保存する
+  header.image_path = header.image_path.replace(app.getAppPath(), '.');
+  header.default_log_directory_path = header.default_log_directory_path.replace(app.getAppPath(), '.');
+  return header;
+};
+
 model.prototype.loadSetting = function ( target_path ) {
   if ( target_path == undefined ) {
     target_path = this.save_setting_path;

--- a/lib/model.js
+++ b/lib/model.js
@@ -4,6 +4,8 @@
  */
 
 const validator = new (require('jsonschema').Validator);
+const remote = require('electron').remote;
+const app = require('electron').app;
 
 function model( win ) {
   this.data = {
@@ -28,7 +30,7 @@ function model( win ) {
   };
   this.win = win;
   this.file = require('fs'),
-  this.save_setting_path = "setting.json";
+  this.save_setting_path = app.getAppPath() + "/setting.json";
 
   this.ipc = require('electron').ipcMain;
   this.ipc.on('updateState', this.onUpdateState.bind(this));
@@ -37,6 +39,8 @@ function model( win ) {
   this.ipc.on('exportSetting', this.onExportSetting.bind(this));
 
   try {
+
+    console.log("loadsetting path: " + this.save_setting_path);
     this.loadSetting( this.save_setting_path );
   } catch ( e ) {
     // デフォルトパスにある設定ファイルが不正な形式である場合
@@ -106,7 +110,7 @@ model.prototype.loadSetting = function ( target_path ) {
 
     try {
       settings = JSON.parse( this.file.readFileSync( target_path ) );
-      schema = JSON.parse( this.file.readFileSync( "lib/model.json" ) );
+      schema = JSON.parse( this.file.readFileSync( app.getAppPath() + "/lib/model.json" ) );
     } catch ( e ) {
       throw Error("Invalid json format");
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -65,7 +65,7 @@ model.prototype.onUpdateState = function ( event, arg ) {
 
   // 設定を保存する
   if ( this.data.app.save_setting ) {
-    this.file.writeFileSync( this.save_setting_path, JSON.stringify( this.data ), 'utf8' );
+    this.writeSetting(this.save_setting_path);
   } else {
     this.onDeleteSettings();
   }
@@ -123,6 +123,13 @@ model.prototype.loadSetting = function ( target_path ) {
 
     // 代入
     this.data.setting = settings.setting;
+
+    // 相対パス表現を絶対パス表現に変換する
+    var image_path = this.data.setting.image_path;
+    var log_path = this.data.setting.default_log_directory_path;
+    this.data.setting.image_path = image_path.replace(/^\./, app.getAppPath());
+    this.data.setting.default_log_directory_path = log_path.replace(/^\./, app.getAppPath());
+
     // デフォルトのログファイルの出力先パスを現在の出力先パスに設定する
     this.data.app.logFileFolder = settings.setting.default_log_directory_path;
     // 設定をロードした場合には、自動的にデータのセーブフラグを入にする
@@ -145,8 +152,25 @@ model.prototype.onImportSetting = function ( event, arg ) {
 };
 
 model.prototype.onExportSetting = function ( event, path ) {
-  this.file.writeFileSync( path, JSON.stringify( this.data ), 'utf8' );
+  this.writeSetting(path);
 };
+
+model.prototype.writeSetting = function ( path ) {
+  var image_path = this.data.setting.image_path;
+  var log_path = this.data.setting.default_log_directory_path;
+
+  // 設定ファイルを共有しやすくするため、
+  // appディレクトリ以下が設定されている時、相対パス表現で保存する
+  this.data.setting.image_path = image_path.replace(app.getAppPath(), '.');
+  this.data.setting.default_log_directory_path = log_path.replace(app.getAppPath(), '.');
+
+  // ファイルに書き出す
+  this.file.writeFileSync( path, JSON.stringify( this.data ), 'utf8' );
+
+  // 内部の状態を元に戻す(絶対パス表現に戻す)
+  this.data.setting.image_path = image_path;
+  this.data.setting.default_log_directory_path = log_path;
+}
 
 
 module.exports = model;

--- a/lib/model.json
+++ b/lib/model.json
@@ -24,7 +24,8 @@
         "image_original_size": { "type": "object" },
         "start_point": { "type": "object" },
         "draw_scale": { "type": "int" },
-        "draw_rotate": { "type": "int" }
+        "draw_rotate": { "type": "int" },
+        "device_name": { "type": "string" }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "bluetooth-serial-port": "2.1.0",
     "bootstrap": "^3.3.7",
     "date-utils": "1.2.7",
-    "electron-prebuilt": "1.1.3",
     "jsonschema": "^1.1.1"
+  },
+  "devDependencies": {
+    "electron": "^1.7.4",
+    "electron-rebuild": "^1.5.11"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "終了するには Ctrl-C を押すか Command-Q で終了してください"
-node_modules/electron-prebuilt/dist/Electron.app/Contents/MacOS/Electron .
+node_modules/.bin/electron .

--- a/src/js/deviceConnector.js
+++ b/src/js/deviceConnector.js
@@ -99,7 +99,7 @@ deviceConnector.prototype.onFoundDevice = function ( ev, message ) {
     this.$('<li>')
       .addClass("device-connector-device-name")
       .text(device.name)
-      .bind( 'click', device.address, this.onSelectDevice.bind(this) ));
+      .bind( 'click', device, this.onSelectDevice.bind(this) ));
 };
 
 /**
@@ -113,7 +113,8 @@ deviceConnector.prototype.onSelectDevice = function ( event ) {
     this.jqueryMap.$selected_device.removeClass("selected");
   }
   // プロパティに追加
-  this.stateMap.selected_device_address = event.data;
+  this.stateMap.selected_device_address = event.data.address;
+  this.stateMap.selected_device = event.data;
   // DOM 要素に描画
   this.jqueryMap.$selected_device = this.$(event.target);
   this.jqueryMap.$selected_device.addClass("selected");
@@ -128,7 +129,7 @@ deviceConnector.prototype.onSelectDevice = function ( event ) {
  */
 deviceConnector.prototype.onConnectDevice = function ( event ) {
   if ( this.stateMap.selected_device_address === undefined ) { return; }
-  this.ipc.send('connectDevice', this.stateMap.selected_device_address);
+  this.ipc.send('connectDevice', this.stateMap.selected_device); // TODO
   this.jqueryMap.$update_btn.addClass('disabled');
   this.jqueryMap.$connect_btn.addClass('disabled');
 };
@@ -167,7 +168,7 @@ deviceConnector.prototype.loadDevices = function () {
       this.$('<li>')
         .addClass( "device-connector-device-name" )
         .text( device.name )
-        .bind( 'click', device.address, this.onSelectDevice.bind(this) ));
+        .bind( 'click', device, this.onSelectDevice.bind(this) ));
   }.bind(this));
 }
 
@@ -240,7 +241,8 @@ deviceConnector.prototype.remove = function () {
   this.stateMap = {
     $append_target          : undefined,
     deviceMap               : [],
-    selected_device_address : undefined
+    selected_device_address : undefined,
+    selected_device         : undefined
   };
   this.callback = undefined;
   this.onNotify = undefined;

--- a/src/js/fileInputForm.js
+++ b/src/js/fileInputForm.js
@@ -64,10 +64,15 @@ fileInputForm.prototype.onUpdateLogFileName = function ( event ) {
  * 選択したフォルダでテキスト領域を更新する．
  */
 fileInputForm.prototype.onSearchDirectory = function ( event ) {
+  var logFilePath = this.ipc.sendSync('getState', { 'doc': 'app', 'key': 'logFileFolder' });
+  if ('' == logFilePath) {
+    // 設定されていなかったらデフォルトの保存先
+    logFilePath = app.getAppPath() + '/log';
+  }
   Dialog.showOpenDialog(null, {
     properties: ['openDirectory'],
     title: 'ログファイル出力先の選択',
-    defaultPath: app.getAppPath() + "/log"
+    defaultPath: logFilePath
   }, function(directories){
     // プロパティに保持
     this.stateMap.logFileFolder = directories[0];

--- a/src/js/fileInputForm.js
+++ b/src/js/fileInputForm.js
@@ -4,6 +4,7 @@
 
 // ファイル選択のためのモジュール
 const remote = require('electron').remote;
+const app = remote.require('electron').app;
 const Dialog = remote.dialog;
 
 function fileInputForm() {
@@ -66,7 +67,7 @@ fileInputForm.prototype.onSearchDirectory = function ( event ) {
   Dialog.showOpenDialog(null, {
     properties: ['openDirectory'],
     title: 'ログファイル出力先の選択',
-    defaultPath: '.'
+    defaultPath: app.getAppPath() + "/log"
   }, function(directories){
     // プロパティに保持
     this.stateMap.logFileFolder = directories[0];

--- a/src/js/logAnalyzer.js
+++ b/src/js/logAnalyzer.js
@@ -59,6 +59,8 @@ function logAnalyzer() {
   }.bind(this));
   this.graphRenderer = new D3GraphRenderer( keymap );
   this.mapRenderer   = new MapRenderer();
+  // main プロセスとの通信用モジュール
+  this.ipc = require('electron').ipcRenderer;
 };
 
 
@@ -71,10 +73,17 @@ function logAnalyzer() {
  * ファイルが選択されると，それを DOM 要素に反映しつつ，プロパティに保持する．
  */
 logAnalyzer.prototype.onSelectFile = function () {
+
+  var logFilePath = this.ipc.sendSync('getState', { 'doc': 'app', 'key': 'logFileFolder' });
+  if ('' == logFilePath) {
+    // 設定されていなかったらデフォルトの保存先
+    logFilePath = app.getAppPath() + '/log';
+  }
+
   Dialog.showOpenDialog(null, {
     properties: ['openFile'],
     title: 'ログファイルの選択',
-    defaultPath: app.getAppPath() + '/log',
+    defaultPath: logFilePath,
     filters: [
       {name: 'JSONファイル', extensions: ['json']}
     ]

--- a/src/js/logAnalyzer.js
+++ b/src/js/logAnalyzer.js
@@ -209,6 +209,12 @@ logAnalyzer.prototype.getLogFileData = function () {
     }
     this.stateMap.logFileSettings = JSON.parse(lines[i]);
   }
+  // 相対パス表現を絶対パス表現に変換する
+  var image_path = this.stateMap.logFileSettings.image_path;
+  var log_path = this.stateMap.logFileSettings.default_log_directory_path;
+  this.stateMap.logFileSettings.image_path = image_path.replace(/^\./, app.getAppPath());
+  this.stateMap.logFileSettings.default_log_directory_path = log_path.replace(/^\./, app.getAppPath());
+
   for (; i<lines.length; i++) {
     values.push(lines[i]);
   }

--- a/src/js/logAnalyzer.js
+++ b/src/js/logAnalyzer.js
@@ -4,6 +4,7 @@
 
 // ファイル選択のためのモジュール
 const remote = require('electron').remote;
+const app = remote.require('electron').app;
 const Dialog = remote.dialog;
 // グラフ描画用のモジュール
 const D3GraphRenderer = require('./renderer/D3GraphRenderer.js');
@@ -73,7 +74,7 @@ logAnalyzer.prototype.onSelectFile = function () {
   Dialog.showOpenDialog(null, {
     properties: ['openFile'],
     title: 'ログファイルの選択',
-    defaultPath: '.',
+    defaultPath: app.getAppPath() + '/log',
     filters: [
       {name: 'JSONファイル', extensions: ['json']}
     ]

--- a/src/js/settings/settingConnect.js
+++ b/src/js/settings/settingConnect.js
@@ -1,5 +1,6 @@
 // ファイル選択のためのモジュール
 const remote = require('electron').remote;
+const app = remote.require('electron').app;
 const Dialog = remote.dialog;
 
 function SettingConnect () {
@@ -36,7 +37,7 @@ SettingConnect.prototype.onFindDefaultPath = function ( event ) {
   Dialog.showOpenDialog(null, {
     properties: ['openDirectory'],
     title: 'ログファイル出力先の選択',
-    defaultPath: '.'
+    defaultPath: app.getAppPath() + "/log"
   }, function(directories){
     // DOM に描画
     this.jqueryMap.$default_path_input.val( directories[0] );

--- a/src/js/settings/settingInfo.js
+++ b/src/js/settings/settingInfo.js
@@ -1,5 +1,6 @@
 // ファイル選択のためのモジュール
 const remote = require('electron').remote;
+const app = remote.require('electron').app;
 const Dialog = remote.dialog;
 
 function SettingInfo () {
@@ -49,7 +50,7 @@ SettingInfo.prototype.onImport = function ( event ) {
   Dialog.showOpenDialog(null, {
     properties: ['openFile'],
     title: 'インポートする設定ファイルの選択',
-    defaultPath: '.'
+    defaultPath: app.getAppPath()
   }, function(files){
     this.ipc.send( 'importSetting', files[0] );
   }.bind(this));
@@ -58,7 +59,7 @@ SettingInfo.prototype.onImport = function ( event ) {
 SettingInfo.prototype.onExport = function ( event ) {
   Dialog.showSaveDialog(null, {
     title: 'エクスポートする設定ファイルの名前',
-    defaultPath: '.',
+    defaultPath: app.getAppPath(),
     filters: [
       {name: 'Setting file', extensions: ['json']}
     ]

--- a/src/js/settings/settingMap.js
+++ b/src/js/settings/settingMap.js
@@ -1,5 +1,6 @@
 // ファイル選択のためのモジュール
 const remote = require('electron').remote;
+const app = remote.require('electron').app;
 const Dialog = remote.dialog;
 const ImageViewer = require("../imageViewer.js");
 
@@ -55,7 +56,7 @@ function SettingMap () {
 SettingMap.prototype.onSelectImage = function ( event ) {
   Dialog.showOpenDialog(null, {
     properties: ['openFile'],
-    defaultPath: '.',
+    defaultPath: app.getAppPath(),
     filters: [
       {name: 'Image file', extensions: ['png', 'jpg', 'jpeg']}
     ]


### PR DESCRIPTION
ログの出力先や画像ファイルのパスを `.app` ファイル内のパスに設定した時、
設定ファイルには`appPath`(`.app`内のソースコードが置いてあるディレクトリ) からの相対パスで保存されるようにしました。

コース画像ファイルを`.app`内に置いて設定しておくと、設定が簡単に共有できるようになります。

このブランチは Pull request #8 , #10 のブランチがマージされています。